### PR TITLE
test: compile project before running test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "GPL-3.0",
   "keywords": [],
   "scripts": {
-    "test": "mocha build/src/**/*.test.js",
+    "test": "npm run pretest && mocha build/src/**/*.test.js",
     "check": "gts check",
     "clean": "gts clean",
     "compile": "tsc -p .",


### PR DESCRIPTION
Hi Gabe (and others), but especially Gabe. Miss you buddy 🙂.

It's useful to recompile a TypeScript project before running its tests, especially because this reduces the context switching a developer may have to think through. Rather than having to remember that they must `npm run compile` and `npm test`, a developer can simply `npm test` (or `yarn test`).